### PR TITLE
Fix: Escape plugin options HTML correctly

### DIFF
--- a/inc/Services/Admin.php
+++ b/inc/Services/Admin.php
@@ -338,7 +338,7 @@ class Admin extends Service implements Kernel {
 	public function position_cb(): void {
 		$positions = '';
 
-		foreach ( [ 'top', 'bottom' ] as $position ) {
+		foreach ( [ 'bottom', 'top' ] as $position ) {
 			$selected = '';
 
 			if ( ( $this->options[ self::NOTICE_POSITION ] ?? '' ) === $position ) {
@@ -361,7 +361,15 @@ class Admin extends Service implements Kernel {
 			esc_attr( self::PLUGIN_OPTION ),
 			esc_attr( self::NOTICE_POSITION ),
 			esc_attr( $this->options[ self::NOTICE_POSITION ] ?? '' ),
-			esc_html( $positions )
+			wp_kses(
+				$positions,
+				[
+					'option' => [
+						'value'    => [],
+						'selected' => [],
+					],
+				]
+			)
 		);
 	}
 
@@ -398,7 +406,15 @@ class Admin extends Service implements Kernel {
 			esc_attr( self::PLUGIN_OPTION ),
 			esc_attr( self::NOTICE_VISIBILITY ),
 			esc_attr( $this->options[ self::NOTICE_VISIBILITY ] ?? '' ),
-			esc_html( $pages )
+			wp_kses(
+				$pages,
+				[
+					'option' => [
+						'value'    => [],
+						'selected' => [],
+					],
+				]
+			)
 		);
 	}
 


### PR DESCRIPTION
This PR resolves the [issue](https://github.com/badasswp/display-site-notification-bar/issues/3).

## Description / Background Context

At the moment, the position and visibility plugin options appear to be hidden. This is because the HTML content is escaped twice. This PR implements a fix for this.

<img width="672" height="597" alt="Screenshot 2025-09-27 at 10 40 19" src="https://github.com/user-attachments/assets/d597f9e8-580d-4e4b-a3dc-0fd7bdae91d1" />

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `yarn build`.
3. Open plugin options page.
4. Observe that Position and Visibility options are correctly populated and are visible.